### PR TITLE
chore: align PR template with CAMARA project format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,57 @@
-## Summary
+#### What type of PR is this?
 
-<!-- What does this PR do? Why is it needed? -->
+Add one of the following kinds:
+* bug
+* fix
+* enhancement/feature
+* refactor
+* documentation
+* tests
+* build/ci
+* chore
 
-## Related issue
 
-Closes #
+#### What this PR does / why we need it:
 
-## Changes
 
-<!-- Bullet list of the main changes -->
 
--
--
 
-## Testing
+#### Which issue(s) this PR fixes:
 
-<!-- How did you verify this works? -->
+<!-- Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->
 
-- [ ] Unit tests added or updated
-- [ ] Integration tests added or updated
-- [ ] Manually tested locally
+Fixes #
 
-## Checklist
 
-- [ ] Code compiles (`./mvnw compile`)
-- [ ] Tests pass (`./mvnw verify`)
-- [ ] Formatted (`./mvnw spotless:apply`)
-- [ ] Docs updated if user-facing
+#### Special notes for reviewers:
+
+
+
+
+#### Changelog input
+
+```
+release-note
+
+```
+
+
+#### Additional documentation
+
+This section can be blank.
+
+```
+docs
+
+```
+
+
+#### Checklist
+
+- [ ] Code compiles (`./gradlew compileJava`)
+- [ ] Tests pass (`./gradlew check`)
+- [ ] Formatted (`./gradlew spotlessApply`)
+- [ ] New features have tests
+- [ ] New user-facing features have docs updated
 - [ ] Commit messages follow conventional commits
-
-## Notes for reviewers
-
-<!-- Anything tricky, any trade-offs, any open questions -->


### PR DESCRIPTION
#### What type of PR is this?

* chore
* documentation

#### What this PR does / why we need it:

Updates `.github/PULL_REQUEST_TEMPLATE.md` to follow the CAMARA project's PR template structure (the de facto standard among multi-vendor OSS API projects).

The new template adds:
- **What type of PR is this?** — explicit PR-type classification (bug / fix / enhancement / feature / refactor / documentation / tests / build/ci / chore)
- **Changelog input** — a code block reviewers can lift directly into release notes
- **Additional documentation** — a code block for related design docs / RFCs / external references

The existing build/test checklist (gradle compile, check, spotlessApply) is preserved at the bottom so contributors don't lose the verification steps.

#### Which issue(s) this PR fixes:

<!-- No tracking issue — meta improvement to contributor experience. -->

Fixes #

#### Special notes for reviewers:

- Reference: [CAMARA VerifiedCaller PR template](https://github.com/camaraproject/VerifiedCaller/blob/main/.github/pull_request_template.md)
- "subproject management" from the CAMARA original was dropped (not relevant here); "build/ci" added.
- Once this lands, every subsequent PR in this session will use the new template.

#### Changelog input

```
Aligned `.github/PULL_REQUEST_TEMPLATE.md` with CAMARA project format. Adds explicit PR-type classification, changelog-input block, and additional-documentation block.
```

#### Additional documentation

This section can be blank.

```
- CAMARA reference template: https://github.com/camaraproject/VerifiedCaller/blob/main/.github/pull_request_template.md
```

#### Checklist

- [x] Code compiles (no code change)
- [x] Tests pass (no code change)
- [x] Formatted (markdown only)
- [ ] New features have tests (n/a)
- [x] New user-facing features have docs updated (this IS the doc)
- [x] Commit messages follow conventional commits