### PR TITLE
docs: add latest-release badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 **The Java-native AI Gateway. One API, every model.**
 
+[![Latest Release](https://img.shields.io/github/v/release/kloudocean/nautilus?style=flat-square&label=release&color=0A1628&include_prereleases&display_name=tag&sort=semver)](https://github.com/kloudocean/nautilus/releases)
 [![Java](https://img.shields.io/badge/Java-21-007396?style=flat-square&logo=openjdk&logoColor=white)](https://openjdk.org/)
 [![Spring Boot](https://img.shields.io/badge/Spring_Boot-3.x-6DB33F?style=flat-square&logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue?style=flat-square)](LICENSE)


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Adds a shields.io GitHub-release badge as the first badge in the README header. Lets users and contributors see the current version at a glance and click through to the releases page.

Badge config:
- `include_prereleases=true` — alpha is current status
- `display_name=tag` and `sort=semver` — surfaces the highest version regardless of release-API ordering
- `color=0A1628` — KloudOcean deep-navy palette

#### Which issue(s) this PR fixes:

Fixes #1

#### Special notes for reviewers:

The badge will render as "no releases" on shields.io until the first GitHub release is cut. That is expected and acceptable — the link still points to the releases page.

#### Changelog input

```
Added a "latest release" shields.io badge to the README header.
```

#### Additional documentation

This section can be blank.

```
Shields.io GitHub release badge: https://shields.io/badges/git-hub-release
```

#### Checklist

- [x] Code compiles (no code change)
- [x] Tests pass (no code change)
- [x] Formatted (markdown only)
- [ ] New features have tests (n/a — docs)
- [x] New user-facing features have docs updated
- [x] Commit messages follow conventional commits