### PR TITLE
ci: add JDK 21 and 23 build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (JDK ${{ matrix.java }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [21, 23]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: gradle build --no-daemon --stacktrace
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-jdk-${{ matrix.java }}
+          path: |
+            build/reports/tests/
+            build/test-results/
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
#### What type of PR is this?

* build/ci

#### What this PR does / why we need it:

Adds `.github/workflows/ci.yml` that builds and tests Nautilus on JDK 21 (the baseline declared in the Gradle toolchain) and JDK 23 (forward-compat smoke test).

Workflow design:
- **Trigger:** push to `main`, PRs targeting `main`.
- **Matrix:** `java: [21, 23]` on `ubuntu-latest` with `fail-fast: false` so a JDK 23 regression does not hide a JDK 21 failure (or vice-versa).
- **Setup:** `actions/setup-java@v4` (Temurin) + `gradle/actions/setup-gradle@v4`.
- **Build step:** `gradle build --no-daemon --stacktrace`.
- **Artifacts:** test reports + result XMLs uploaded per JDK for 7 days, easing triage when one matrix leg fails.
- **Concurrency:** `cancel-in-progress` on the ref to avoid burning runners on rapid pushes.
- **Permissions:** `contents: read` only — least-privilege.

#### Which issue(s) this PR fixes:

Fixes #14

#### Special notes for reviewers:

The job runs `gradle build` directly (via the setup-gradle action) instead of `./gradlew build` because the Gradle wrapper is not committed to the repo yet. Once a follow-up PR adds `./gradlew` + `gradle/wrapper/`, the run line should switch to `./gradlew build`. Worth a separate `chore: add Gradle wrapper` issue if one does not exist.

The workflow will fail on first run unless the existing scaffold compiles cleanly — please verify the green check before merging. If `gradle build` flakes, we may need to swap to `gradle assemble` + `gradle test` until the test scaffold stabilizes.

#### Changelog input

```
Added GitHub Actions CI workflow with JDK 21 and JDK 23 matrix builds. Test reports archived per JDK as build artifacts.
```

#### Additional documentation

This section can be blank.

```
- gradle/actions setup-gradle: https://github.com/gradle/actions/tree/main/setup-gradle
- actions/setup-java: https://github.com/actions/setup-java
```

#### Checklist

- [ ] Code compiles (`./gradlew compileJava`) — N/A: this PR adds CI that will run compile
- [ ] Tests pass (`./gradlew check`) — verified by the workflow itself
- [x] Formatted (yaml)
- [ ] New features have tests (n/a — CI workflow is the test infrastructure)
- [x] New user-facing features have docs updated (badge to be added once first run is green)
- [x] Commit messages follow conventional commits