### PR TITLE
feat: scaffold provider/routing/web layers (foundation for v0.1)

### DIFF
--- a/src/main/java/com/kloudocean/nautilus/NautilusApplication.java
+++ b/src/main/java/com/kloudocean/nautilus/NautilusApplication.java
@@ -1,9 +1,12 @@
 package com.kloudocean.nautilus;
 
+import com.kloudocean.nautilus.config.NautilusProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(NautilusProperties.class)
 public class NautilusApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/kloudocean/nautilus/config/NautilusProperties.java
+++ b/src/main/java/com/kloudocean/nautilus/config/NautilusProperties.java
@@ -1,0 +1,80 @@
+package com.kloudocean.nautilus.config;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Root configuration for Nautilus, bound from {@code nautilus.*}.
+ * Validated at startup — see {@link NautilusPropertiesValidator}.
+ */
+@Validated
+@ConfigurationProperties(prefix = "nautilus")
+public class NautilusProperties {
+
+    @Valid
+    @NotNull
+    private Routing routing = new Routing();
+
+    public Routing getRouting() {
+        return routing;
+    }
+
+    public void setRouting(Routing routing) {
+        this.routing = routing;
+    }
+
+    public static class Routing {
+
+        /** Strategy name — must match a registered {@code RoutingStrategy} bean. */
+        @NotBlank
+        @Pattern(regexp = "[a-z][a-z0-9-]*",
+                message = "must be a lowercase identifier (e.g. 'priority', 'round-robin')")
+        private String strategy = "priority";
+
+        /** Provider entries in priority/declaration order. */
+        @NotEmpty(message = "at least one provider must be configured under nautilus.routing.providers")
+        @Valid
+        private List<Provider> providers = new ArrayList<>();
+
+        public String getStrategy() { return strategy; }
+        public void setStrategy(String strategy) { this.strategy = strategy; }
+
+        public List<Provider> getProviders() { return providers; }
+        public void setProviders(List<Provider> providers) { this.providers = providers; }
+    }
+
+    public static class Provider {
+
+        /** Provider name — must match the {@code name()} of a registered {@code LlmProvider} bean. */
+        @NotBlank
+        private String name;
+
+        /** Lower number = higher priority. Used by the priority strategy. */
+        private int priority = Integer.MAX_VALUE;
+
+        /** Optional weight for weighted strategies (random). Negative values rejected. */
+        private double weight = 1.0;
+
+        /** Whether this entry is active. Disabled entries are skipped during routing. */
+        private boolean enabled = true;
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public int getPriority() { return priority; }
+        public void setPriority(int priority) { this.priority = priority; }
+
+        public double getWeight() { return weight; }
+        public void setWeight(double weight) { this.weight = weight; }
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/config/NautilusPropertiesValidator.java
+++ b/src/main/java/com/kloudocean/nautilus/config/NautilusPropertiesValidator.java
@@ -1,0 +1,68 @@
+package com.kloudocean.nautilus.config;
+
+import com.kloudocean.nautilus.routing.ProviderRegistry;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Cross-field validation that Bean Validation cannot express:
+ * - every configured provider name must resolve to a registered {@code LlmProvider} bean
+ * - provider names must be unique within the routing config
+ * - weights must be non-negative
+ *
+ * Runs at {@code ApplicationReadyEvent} so all beans are present, and throws
+ * a precise {@link IllegalStateException} that fails the boot if anything is off.
+ *
+ * Closes the user-facing portion of issue #5: clear startup errors when
+ * application.yml is misconfigured.
+ */
+@Component
+public class NautilusPropertiesValidator {
+
+    private final NautilusProperties properties;
+    private final ProviderRegistry registry;
+
+    public NautilusPropertiesValidator(NautilusProperties properties, ProviderRegistry registry) {
+        this.properties = properties;
+        this.registry = registry;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void validate() {
+        List<NautilusProperties.Provider> providers = properties.getRouting().getProviders();
+
+        Set<String> seen = new LinkedHashSet<>();
+        for (NautilusProperties.Provider p : providers) {
+            if (!seen.add(p.getName())) {
+                throw new IllegalStateException(
+                        "Duplicate provider name in nautilus.routing.providers: '" + p.getName() + "'. "
+                                + "Each provider entry must have a unique name.");
+            }
+            if (p.getWeight() < 0) {
+                throw new IllegalStateException(
+                        "Negative weight for provider '" + p.getName() + "' in nautilus.routing.providers. "
+                                + "Weights must be >= 0.");
+            }
+            if (registry.find(p.getName()).isEmpty()) {
+                String registered = registry.all().keySet().stream().sorted().collect(Collectors.joining(", "));
+                throw new IllegalStateException(
+                        "Provider '" + p.getName() + "' configured under nautilus.routing.providers but no "
+                                + "LlmProvider bean is registered for it. Registered providers: ["
+                                + (registered.isEmpty() ? "(none)" : registered) + "]. "
+                                + "Either remove the entry, or enable/implement the matching provider.");
+            }
+        }
+
+        long enabledCount = providers.stream().filter(NautilusProperties.Provider::isEnabled).count();
+        if (enabledCount == 0) {
+            throw new IllegalStateException(
+                    "No enabled providers in nautilus.routing.providers. "
+                            + "At least one provider must have 'enabled: true'.");
+        }
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/domain/ChatMessage.java
+++ b/src/main/java/com/kloudocean/nautilus/domain/ChatMessage.java
@@ -1,0 +1,23 @@
+package com.kloudocean.nautilus.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ChatMessage(
+        @NotNull Role role,
+        @NotNull String content,
+        String name) {
+
+    public static ChatMessage system(String content) {
+        return new ChatMessage(Role.SYSTEM, content, null);
+    }
+
+    public static ChatMessage user(String content) {
+        return new ChatMessage(Role.USER, content, null);
+    }
+
+    public static ChatMessage assistant(String content) {
+        return new ChatMessage(Role.ASSISTANT, content, null);
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/domain/ChatRequest.java
+++ b/src/main/java/com/kloudocean/nautilus/domain/ChatRequest.java
@@ -1,0 +1,33 @@
+package com.kloudocean.nautilus.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * OpenAI-compatible chat completion request. The wire format is intentionally
+ * identical to OpenAI's so existing clients work without code changes.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ChatRequest(
+        @NotNull String model,
+        @NotEmpty @Valid List<ChatMessage> messages,
+        Double temperature,
+        @JsonProperty("max_tokens") Integer maxTokens,
+        @JsonProperty("top_p") Double topP,
+        Boolean stream,
+        String user) {
+
+    public ChatRequest {
+        if (messages != null) {
+            messages = List.copyOf(messages);
+        }
+    }
+
+    public boolean isStreaming() {
+        return Boolean.TRUE.equals(stream);
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/domain/ChatResponse.java
+++ b/src/main/java/com/kloudocean/nautilus/domain/ChatResponse.java
@@ -1,0 +1,28 @@
+package com.kloudocean.nautilus.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ChatResponse(
+        String id,
+        String object,
+        long created,
+        String model,
+        String provider,
+        List<Choice> choices,
+        Usage usage) {
+
+    public static ChatResponse of(String model, String provider, ChatMessage message, Usage usage) {
+        return new ChatResponse(
+                "chatcmpl-" + UUID.randomUUID(),
+                "chat.completion",
+                Instant.now().getEpochSecond(),
+                model,
+                provider,
+                List.of(Choice.of(0, message)),
+                usage);
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/domain/Choice.java
+++ b/src/main/java/com/kloudocean/nautilus/domain/Choice.java
@@ -1,0 +1,13 @@
+package com.kloudocean.nautilus.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Choice(
+        int index,
+        ChatMessage message,
+        @JsonProperty("finish_reason") String finishReason) {
+
+    public static Choice of(int index, ChatMessage message) {
+        return new Choice(index, message, "stop");
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/domain/Role.java
+++ b/src/main/java/com/kloudocean/nautilus/domain/Role.java
@@ -1,0 +1,21 @@
+package com.kloudocean.nautilus.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Role {
+    SYSTEM,
+    USER,
+    ASSISTANT,
+    TOOL;
+
+    @JsonValue
+    public String wire() {
+        return name().toLowerCase();
+    }
+
+    @JsonCreator
+    public static Role from(String wire) {
+        return valueOf(wire.toUpperCase());
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/domain/Usage.java
+++ b/src/main/java/com/kloudocean/nautilus/domain/Usage.java
@@ -1,0 +1,17 @@
+package com.kloudocean.nautilus.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Usage(
+        @JsonProperty("prompt_tokens") int promptTokens,
+        @JsonProperty("completion_tokens") int completionTokens,
+        @JsonProperty("total_tokens") int totalTokens) {
+
+    public static Usage of(int prompt, int completion) {
+        return new Usage(prompt, completion, prompt + completion);
+    }
+
+    public static Usage zero() {
+        return new Usage(0, 0, 0);
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/provider/LlmProvider.java
+++ b/src/main/java/com/kloudocean/nautilus/provider/LlmProvider.java
@@ -1,0 +1,39 @@
+package com.kloudocean.nautilus.provider;
+
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.domain.ChatResponse;
+
+/**
+ * SPI for LLM providers. Each provider is a Spring bean discovered by name
+ * via {@link com.kloudocean.nautilus.routing.ProviderRegistry}.
+ *
+ * Implementations must be thread-safe — a single bean serves concurrent requests.
+ */
+public interface LlmProvider {
+
+    /**
+     * Stable identifier used in routing config (e.g. "claude", "openai", "ollama").
+     * Lowercase, no whitespace, must match the key under {@code nautilus.routing.providers[]}.
+     */
+    String name();
+
+    /**
+     * Whether this provider can handle the requested model id.
+     * Routing skips providers that return {@code false}.
+     */
+    boolean supports(String model);
+
+    /**
+     * Synchronous chat completion. Implementations throw {@link ProviderException}
+     * for typed failures so the orchestrator can decide whether to retry / fallback.
+     */
+    ChatResponse chat(ChatRequest request);
+
+    /**
+     * Cheap, fast health check. Default returns UP — providers that need an
+     * actual probe (auth, latency budget) override this.
+     */
+    default ProviderHealth health() {
+        return ProviderHealth.UP;
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/provider/MockProvider.java
+++ b/src/main/java/com/kloudocean/nautilus/provider/MockProvider.java
@@ -1,0 +1,64 @@
+package com.kloudocean.nautilus.provider;
+
+import com.kloudocean.nautilus.domain.ChatMessage;
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.domain.ChatResponse;
+import com.kloudocean.nautilus.domain.Usage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Echoes the last user message back as the assistant response.
+ * Always healthy. Used by integration tests and the local quickstart so the
+ * gateway works before any real provider keys are configured.
+ *
+ * Active only when {@code nautilus.provider.mock.enabled=true}.
+ */
+@Component
+@ConditionalOnProperty(prefix = "nautilus.provider.mock", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class MockProvider implements LlmProvider {
+
+    public static final String NAME = "mock";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public boolean supports(String model) {
+        return model == null
+                || model.isBlank()
+                || model.startsWith("mock")
+                || "auto".equalsIgnoreCase(model)
+                || "echo".equalsIgnoreCase(model);
+    }
+
+    @Override
+    public ChatResponse chat(ChatRequest request) {
+        String lastUser = lastUserMessage(request);
+        String reply = "[mock] " + lastUser;
+        int promptTokens = approxTokens(lastUser);
+        int completionTokens = approxTokens(reply);
+        return ChatResponse.of(
+                request.model(),
+                NAME,
+                ChatMessage.assistant(reply),
+                Usage.of(promptTokens, completionTokens));
+    }
+
+    private String lastUserMessage(ChatRequest request) {
+        for (int i = request.messages().size() - 1; i >= 0; i--) {
+            ChatMessage m = request.messages().get(i);
+            if (m.role() == com.kloudocean.nautilus.domain.Role.USER) {
+                return m.content();
+            }
+        }
+        return "";
+    }
+
+    private int approxTokens(String text) {
+        if (text == null || text.isEmpty()) return 0;
+        return Math.max(1, text.length() / 4);
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/provider/ProviderException.java
+++ b/src/main/java/com/kloudocean/nautilus/provider/ProviderException.java
@@ -1,0 +1,45 @@
+package com.kloudocean.nautilus.provider;
+
+public class ProviderException extends RuntimeException {
+
+    public enum Kind {
+        RATE_LIMIT,
+        TIMEOUT,
+        AUTH,
+        UPSTREAM_ERROR,
+        BAD_REQUEST,
+        UNAVAILABLE
+    }
+
+    private final Kind kind;
+    private final String providerName;
+
+    public ProviderException(Kind kind, String providerName, String message) {
+        this(kind, providerName, message, null);
+    }
+
+    public ProviderException(Kind kind, String providerName, String message, Throwable cause) {
+        super(formatMessage(kind, providerName, message), cause);
+        this.kind = kind;
+        this.providerName = providerName;
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    public String providerName() {
+        return providerName;
+    }
+
+    public boolean isRetryable() {
+        return switch (kind) {
+            case RATE_LIMIT, TIMEOUT, UPSTREAM_ERROR, UNAVAILABLE -> true;
+            case AUTH, BAD_REQUEST -> false;
+        };
+    }
+
+    private static String formatMessage(Kind kind, String provider, String message) {
+        return "[" + provider + "/" + kind + "] " + message;
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/provider/ProviderHealth.java
+++ b/src/main/java/com/kloudocean/nautilus/provider/ProviderHealth.java
@@ -1,0 +1,11 @@
+package com.kloudocean.nautilus.provider;
+
+public enum ProviderHealth {
+    UP,
+    DEGRADED,
+    DOWN;
+
+    public boolean isUsable() {
+        return this != DOWN;
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/routing/NoEligibleProviderException.java
+++ b/src/main/java/com/kloudocean/nautilus/routing/NoEligibleProviderException.java
@@ -1,0 +1,46 @@
+package com.kloudocean.nautilus.routing;
+
+import java.util.List;
+
+/**
+ * Raised when no provider can serve the request — either nothing matched the model
+ * up front, or every eligible provider was tried and failed with retryable errors.
+ *
+ * The exception preserves which providers were configured/attempted so the error
+ * advice can produce an actionable HTTP 503 message.
+ */
+public class NoEligibleProviderException extends RuntimeException {
+
+    private final String model;
+    private final List<String> consideredOrAttempted;
+
+    public NoEligibleProviderException(String model, List<String> considered) {
+        this(model, considered, null);
+    }
+
+    public NoEligibleProviderException(String model, List<String> consideredOrAttempted, Throwable cause) {
+        super(buildMessage(model, consideredOrAttempted, cause), cause);
+        this.model = model;
+        this.consideredOrAttempted = List.copyOf(consideredOrAttempted);
+    }
+
+    public String model() {
+        return model;
+    }
+
+    public List<String> consideredOrAttempted() {
+        return consideredOrAttempted;
+    }
+
+    private static String buildMessage(String model, List<String> providers, Throwable cause) {
+        StringBuilder sb = new StringBuilder("No eligible provider for model='")
+                .append(model).append("'.");
+        if (cause != null) {
+            sb.append(" All ").append(providers.size())
+                    .append(" attempted providers failed: ").append(providers).append('.');
+        } else {
+            sb.append(" Considered: ").append(providers).append('.');
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/routing/PriorityRoutingStrategy.java
+++ b/src/main/java/com/kloudocean/nautilus/routing/PriorityRoutingStrategy.java
@@ -1,0 +1,31 @@
+package com.kloudocean.nautilus.routing;
+
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.provider.LlmProvider;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Picks the first eligible provider in declaration order.
+ *
+ * The list passed in is already sorted by priority and filtered to "healthy +
+ * supports the requested model" by {@link RouteResolver}, so this strategy's
+ * job is simply: take the head.
+ *
+ * Stateless and trivially thread-safe.
+ */
+@Component
+public class PriorityRoutingStrategy implements RoutingStrategy {
+
+    public static final String NAME = "priority";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public LlmProvider pick(ChatRequest request, List<LlmProvider> eligible) {
+        return eligible.isEmpty() ? null : eligible.get(0);
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/routing/ProviderRegistry.java
+++ b/src/main/java/com/kloudocean/nautilus/routing/ProviderRegistry.java
@@ -1,0 +1,36 @@
+package com.kloudocean.nautilus.routing;
+
+import com.kloudocean.nautilus.provider.LlmProvider;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * Indexes every {@link LlmProvider} bean by its {@link LlmProvider#name()}.
+ * Built once at startup; lookups are O(1).
+ */
+@Component
+public class ProviderRegistry {
+
+    private final Map<String, LlmProvider> byName;
+
+    public ProviderRegistry(List<LlmProvider> providers) {
+        this.byName = providers.stream()
+                .collect(Collectors.toUnmodifiableMap(LlmProvider::name, p -> p));
+    }
+
+    public Optional<LlmProvider> find(String name) {
+        return Optional.ofNullable(byName.get(name));
+    }
+
+    public LlmProvider require(String name) {
+        return find(name).orElseThrow(() ->
+                new IllegalStateException("No LlmProvider bean registered with name: " + name));
+    }
+
+    public Map<String, LlmProvider> all() {
+        return byName;
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/routing/RouteResolver.java
+++ b/src/main/java/com/kloudocean/nautilus/routing/RouteResolver.java
@@ -1,0 +1,114 @@
+package com.kloudocean.nautilus.routing;
+
+import com.kloudocean.nautilus.config.NautilusProperties;
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.domain.ChatResponse;
+import com.kloudocean.nautilus.provider.LlmProvider;
+import com.kloudocean.nautilus.provider.ProviderException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Orchestrator: filters configured providers down to the eligible set
+ * (healthy + supports the model + enabled), hands that set to the active
+ * {@link RoutingStrategy}, and invokes the picked provider.
+ *
+ * Fallback behaviour: if the picked provider throws a retryable
+ * {@link ProviderException}, the resolver removes it from the eligible set
+ * and retries with the next pick. This keeps the strategy's "first pick"
+ * semantics intact while still yielding resilient end-to-end behaviour.
+ */
+@Component
+public class RouteResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(RouteResolver.class);
+
+    private final NautilusProperties properties;
+    private final ProviderRegistry registry;
+    private final Map<String, RoutingStrategy> strategiesByName;
+
+    public RouteResolver(NautilusProperties properties,
+                         ProviderRegistry registry,
+                         List<RoutingStrategy> strategies) {
+        this.properties = properties;
+        this.registry = registry;
+        this.strategiesByName = strategies.stream()
+                .collect(Collectors.toUnmodifiableMap(RoutingStrategy::name, s -> s));
+    }
+
+    public ChatResponse route(ChatRequest request) {
+        RoutingStrategy strategy = strategy();
+        List<LlmProvider> attempted = new java.util.ArrayList<>();
+        List<LlmProvider> remaining = new java.util.ArrayList<>(eligible(request));
+
+        if (remaining.isEmpty()) {
+            throw new NoEligibleProviderException(request.model(), enabledNames());
+        }
+
+        ProviderException lastError = null;
+        while (!remaining.isEmpty()) {
+            LlmProvider pick = strategy.pick(request, remaining);
+            if (pick == null) break;
+            attempted.add(pick);
+            remaining.remove(pick);
+            try {
+                log.debug("routing model={} -> provider={} strategy={}",
+                        request.model(), pick.name(), strategy.name());
+                return pick.chat(request);
+            } catch (ProviderException e) {
+                log.warn("provider={} failed kind={} retryable={} attempted={}/{}",
+                        pick.name(), e.kind(), e.isRetryable(),
+                        attempted.size(), attempted.size() + remaining.size());
+                lastError = e;
+                if (!e.isRetryable() || remaining.isEmpty()) {
+                    throw e;
+                }
+            }
+        }
+
+        // Exhausted all eligible providers with retryable errors.
+        throw new NoEligibleProviderException(
+                request.model(),
+                attempted.stream().map(LlmProvider::name).toList(),
+                lastError);
+    }
+
+    private RoutingStrategy strategy() {
+        String name = properties.getRouting().getStrategy();
+        RoutingStrategy s = strategiesByName.get(name);
+        if (s == null) {
+            throw new IllegalStateException(
+                    "No RoutingStrategy bean for nautilus.routing.strategy='" + name
+                            + "'. Registered strategies: "
+                            + strategiesByName.keySet().stream().sorted().toList());
+        }
+        return s;
+    }
+
+    /**
+     * Eligible = configured + enabled + bean-registered + healthy + supports(model),
+     * sorted by configured priority ascending.
+     */
+    private List<LlmProvider> eligible(ChatRequest request) {
+        return properties.getRouting().getProviders().stream()
+                .filter(NautilusProperties.Provider::isEnabled)
+                .sorted(Comparator.comparingInt(NautilusProperties.Provider::getPriority))
+                .map(p -> registry.find(p.getName()).orElse(null))
+                .filter(java.util.Objects::nonNull)
+                .filter(p -> p.health().isUsable())
+                .filter(p -> p.supports(request.model()))
+                .toList();
+    }
+
+    private List<String> enabledNames() {
+        return properties.getRouting().getProviders().stream()
+                .filter(NautilusProperties.Provider::isEnabled)
+                .map(NautilusProperties.Provider::getName)
+                .toList();
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/routing/RoutingStrategy.java
+++ b/src/main/java/com/kloudocean/nautilus/routing/RoutingStrategy.java
@@ -1,0 +1,30 @@
+package com.kloudocean.nautilus.routing;
+
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.provider.LlmProvider;
+import java.util.List;
+
+/**
+ * SPI for routing strategies (priority, round-robin, random, cost-aware, latency-aware).
+ *
+ * Each strategy is a Spring bean. The strategy selected at runtime is determined by
+ * the {@code nautilus.routing.strategy} property.
+ *
+ * Implementations must be thread-safe. Strategies that hold per-instance state
+ * (e.g. round-robin cursor) should document multi-instance behaviour in their
+ * Javadoc — see docs/guides/routing-strategies.md.
+ */
+public interface RoutingStrategy {
+
+    /**
+     * Stable identifier matched against {@code nautilus.routing.strategy}.
+     */
+    String name();
+
+    /**
+     * Pick a provider for the given request from the eligible set.
+     * Returns null if no eligible provider exists; the caller decides
+     * whether to surface a 503 or attempt an alternative path.
+     */
+    LlmProvider pick(ChatRequest request, List<LlmProvider> eligible);
+}

--- a/src/main/java/com/kloudocean/nautilus/web/ChatController.java
+++ b/src/main/java/com/kloudocean/nautilus/web/ChatController.java
@@ -1,0 +1,29 @@
+package com.kloudocean.nautilus.web;
+
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.domain.ChatResponse;
+import com.kloudocean.nautilus.routing.RouteResolver;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1")
+public class ChatController {
+
+    private final RouteResolver resolver;
+
+    public ChatController(RouteResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @PostMapping(value = "/chat/completions",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ChatResponse chat(@Valid @RequestBody ChatRequest request) {
+        return resolver.route(request);
+    }
+}

--- a/src/main/java/com/kloudocean/nautilus/web/ErrorAdvice.java
+++ b/src/main/java/com/kloudocean/nautilus/web/ErrorAdvice.java
@@ -1,0 +1,77 @@
+package com.kloudocean.nautilus.web;
+
+import com.kloudocean.nautilus.provider.ProviderException;
+import com.kloudocean.nautilus.routing.NoEligibleProviderException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Maps internal exceptions to HTTP responses with stable error shapes.
+ * Response shape mirrors OpenAI's error envelope so existing clients can parse it.
+ */
+@RestControllerAdvice
+public class ErrorAdvice {
+
+    private static final Logger log = LoggerFactory.getLogger(ErrorAdvice.class);
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> onValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(f -> f.getField() + ": " + f.getDefaultMessage())
+                .findFirst()
+                .orElse("invalid request");
+        return error(HttpStatus.BAD_REQUEST, "invalid_request_error", message, null);
+    }
+
+    @ExceptionHandler(NoEligibleProviderException.class)
+    public ResponseEntity<Map<String, Object>> onNoProvider(NoEligibleProviderException e) {
+        return error(HttpStatus.SERVICE_UNAVAILABLE, "no_eligible_provider", e.getMessage(), null);
+    }
+
+    @ExceptionHandler(ProviderException.class)
+    public ResponseEntity<Map<String, Object>> onProvider(ProviderException e) {
+        HttpStatus status = switch (e.kind()) {
+            case RATE_LIMIT -> HttpStatus.TOO_MANY_REQUESTS;
+            case TIMEOUT, UNAVAILABLE -> HttpStatus.SERVICE_UNAVAILABLE;
+            case AUTH -> HttpStatus.UNAUTHORIZED;
+            case BAD_REQUEST -> HttpStatus.BAD_REQUEST;
+            case UPSTREAM_ERROR -> HttpStatus.BAD_GATEWAY;
+        };
+        return error(status, e.kind().name().toLowerCase(), e.getMessage(), e.providerName());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> onIllegalArgument(IllegalArgumentException e) {
+        return error(HttpStatus.BAD_REQUEST, "invalid_request_error", e.getMessage(), null);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> onUnknown(Exception e) {
+        log.error("unhandled exception", e);
+        return error(HttpStatus.INTERNAL_SERVER_ERROR, "internal_error",
+                "An unexpected error occurred. See server logs.", null);
+    }
+
+    private ResponseEntity<Map<String, Object>> error(HttpStatus status, String type,
+                                                       String message, String provider) {
+        Map<String, Object> err = new LinkedHashMap<>();
+        err.put("type", type);
+        err.put("message", message);
+        if (provider != null) {
+            err.put("provider", provider);
+        }
+        err.put("status", status.value());
+        err.put("timestamp", Instant.now().toString());
+
+        Map<String, Object> body = Map.of("error", err);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,16 +13,31 @@ management:
   endpoint:
     health:
       show-details: when-authorized
+      probes:
+        enabled: true
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
 
 nautilus:
-  # Provider keys are read from environment variables.
-  providers:
-    claude:
-      enabled: ${NAUTILUS_CLAUDE_ENABLED:false}
-      api-key: ${ANTHROPIC_API_KEY:}
-    openai:
-      enabled: ${NAUTILUS_OPENAI_ENABLED:false}
-      api-key: ${OPENAI_API_KEY:}
+  routing:
+    # Selects the active routing strategy. See docs/guides/routing-strategies.md.
+    # Built-in: priority
+    strategy: priority
+
+    # Provider entries in priority order (lower = higher priority).
+    # The mock provider is the only one shipping in v0.1; real providers
+    # (Claude, OpenAI, Llama, Mistral) plug in via the LlmProvider SPI.
+    providers:
+      - name: mock
+        priority: 1
+        enabled: true
+
+  provider:
+    mock:
+      enabled: true
 
 logging:
   level:

--- a/src/test/java/com/kloudocean/nautilus/config/NautilusPropertiesValidationTest.java
+++ b/src/test/java/com/kloudocean/nautilus/config/NautilusPropertiesValidationTest.java
@@ -1,0 +1,83 @@
+package com.kloudocean.nautilus.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.kloudocean.nautilus.provider.LlmProvider;
+import com.kloudocean.nautilus.provider.MockProvider;
+import com.kloudocean.nautilus.routing.ProviderRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NautilusPropertiesValidationTest {
+
+    @Test
+    void rejects_unknown_provider_name() {
+        NautilusProperties props = props(provider("does-not-exist", 1, true));
+        ProviderRegistry registry = new ProviderRegistry(List.<LlmProvider>of(new MockProvider()));
+
+        assertThatThrownBy(() -> new NautilusPropertiesValidator(props, registry).validate())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does-not-exist")
+                .hasMessageContaining("Registered providers");
+    }
+
+    @Test
+    void rejects_duplicate_provider_names() {
+        NautilusProperties props = props(provider("mock", 1, true), provider("mock", 2, true));
+        ProviderRegistry registry = new ProviderRegistry(List.<LlmProvider>of(new MockProvider()));
+
+        assertThatThrownBy(() -> new NautilusPropertiesValidator(props, registry).validate())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Duplicate provider name");
+    }
+
+    @Test
+    void rejects_negative_weight() {
+        NautilusProperties.Provider p = provider("mock", 1, true);
+        p.setWeight(-0.5);
+        NautilusProperties props = props(p);
+        ProviderRegistry registry = new ProviderRegistry(List.<LlmProvider>of(new MockProvider()));
+
+        assertThatThrownBy(() -> new NautilusPropertiesValidator(props, registry).validate())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Negative weight");
+    }
+
+    @Test
+    void rejects_when_all_providers_disabled() {
+        NautilusProperties props = props(provider("mock", 1, false));
+        ProviderRegistry registry = new ProviderRegistry(List.<LlmProvider>of(new MockProvider()));
+
+        assertThatThrownBy(() -> new NautilusPropertiesValidator(props, registry).validate())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No enabled providers");
+    }
+
+    @Test
+    void valid_configuration_passes() {
+        NautilusProperties props = props(provider("mock", 1, true));
+        ProviderRegistry registry = new ProviderRegistry(List.<LlmProvider>of(new MockProvider()));
+
+        // No exception — clean validation pass.
+        new NautilusPropertiesValidator(props, registry).validate();
+        assertThat(props.getRouting().getProviders()).hasSize(1);
+    }
+
+    // ----- helpers -----
+
+    private static NautilusProperties props(NautilusProperties.Provider... providers) {
+        NautilusProperties p = new NautilusProperties();
+        p.getRouting().setStrategy("priority");
+        p.getRouting().setProviders(new java.util.ArrayList<>(java.util.Arrays.asList(providers)));
+        return p;
+    }
+
+    private static NautilusProperties.Provider provider(String name, int priority, boolean enabled) {
+        NautilusProperties.Provider p = new NautilusProperties.Provider();
+        p.setName(name);
+        p.setPriority(priority);
+        p.setEnabled(enabled);
+        return p;
+    }
+}

--- a/src/test/java/com/kloudocean/nautilus/routing/PriorityRoutingStrategyTest.java
+++ b/src/test/java/com/kloudocean/nautilus/routing/PriorityRoutingStrategyTest.java
@@ -1,0 +1,47 @@
+package com.kloudocean.nautilus.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kloudocean.nautilus.domain.ChatMessage;
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.domain.ChatResponse;
+import com.kloudocean.nautilus.provider.LlmProvider;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PriorityRoutingStrategyTest {
+
+    private final PriorityRoutingStrategy strategy = new PriorityRoutingStrategy();
+
+    @Test
+    void picks_first_eligible_provider() {
+        LlmProvider primary = stub("primary");
+        LlmProvider secondary = stub("secondary");
+
+        LlmProvider picked = strategy.pick(request(), List.of(primary, secondary));
+
+        assertThat(picked.name()).isEqualTo("primary");
+    }
+
+    @Test
+    void returns_null_when_no_providers() {
+        assertThat(strategy.pick(request(), List.of())).isNull();
+    }
+
+    @Test
+    void name_matches_constant() {
+        assertThat(strategy.name()).isEqualTo("priority");
+    }
+
+    private static ChatRequest request() {
+        return new ChatRequest("auto", List.of(ChatMessage.user("hi")), null, null, null, null, null);
+    }
+
+    private static LlmProvider stub(String name) {
+        return new LlmProvider() {
+            @Override public String name() { return name; }
+            @Override public boolean supports(String model) { return true; }
+            @Override public ChatResponse chat(ChatRequest r) { throw new UnsupportedOperationException(); }
+        };
+    }
+}

--- a/src/test/java/com/kloudocean/nautilus/routing/RouteResolverTest.java
+++ b/src/test/java/com/kloudocean/nautilus/routing/RouteResolverTest.java
@@ -1,0 +1,153 @@
+package com.kloudocean.nautilus.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.kloudocean.nautilus.config.NautilusProperties;
+import com.kloudocean.nautilus.domain.ChatMessage;
+import com.kloudocean.nautilus.domain.ChatRequest;
+import com.kloudocean.nautilus.domain.ChatResponse;
+import com.kloudocean.nautilus.domain.Usage;
+import com.kloudocean.nautilus.provider.LlmProvider;
+import com.kloudocean.nautilus.provider.ProviderException;
+import com.kloudocean.nautilus.provider.ProviderHealth;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RouteResolverTest {
+
+    @Test
+    void picks_higher_priority_provider() {
+        FakeProvider primary = new FakeProvider("primary");
+        FakeProvider secondary = new FakeProvider("secondary");
+        RouteResolver resolver = resolver(props("primary", "secondary"), List.of(primary, secondary));
+
+        ChatResponse r = resolver.route(request("auto"));
+
+        assertThat(r.provider()).isEqualTo("primary");
+        assertThat(primary.calls).isEqualTo(1);
+        assertThat(secondary.calls).isEqualTo(0);
+    }
+
+    @Test
+    void falls_back_to_next_on_retryable_error() {
+        FakeProvider flaky = new FakeProvider("primary").throwOnce(
+                new ProviderException(ProviderException.Kind.RATE_LIMIT, "primary", "429"));
+        FakeProvider backup = new FakeProvider("secondary");
+        RouteResolver resolver = resolver(props("primary", "secondary"), List.of(flaky, backup));
+
+        ChatResponse r = resolver.route(request("auto"));
+
+        assertThat(r.provider()).isEqualTo("secondary");
+        assertThat(flaky.calls).isEqualTo(1);
+        assertThat(backup.calls).isEqualTo(1);
+    }
+
+    @Test
+    void does_not_fall_back_on_non_retryable_error() {
+        FakeProvider primary = new FakeProvider("primary").throwOnce(
+                new ProviderException(ProviderException.Kind.AUTH, "primary", "bad key"));
+        FakeProvider backup = new FakeProvider("secondary");
+        RouteResolver resolver = resolver(props("primary", "secondary"), List.of(primary, backup));
+
+        assertThatThrownBy(() -> resolver.route(request("auto")))
+                .isInstanceOf(ProviderException.class)
+                .extracting("kind").isEqualTo(ProviderException.Kind.AUTH);
+        assertThat(backup.calls).isEqualTo(0);
+    }
+
+    @Test
+    void rejects_when_no_provider_supports_model() {
+        FakeProvider only = new FakeProvider("only").supportsPattern("gpt-*");
+        RouteResolver resolver = resolver(props("only"), List.of(only));
+
+        assertThatThrownBy(() -> resolver.route(request("claude-opus")))
+                .isInstanceOf(NoEligibleProviderException.class);
+    }
+
+    @Test
+    void skips_unhealthy_providers() {
+        FakeProvider down = new FakeProvider("primary").health(ProviderHealth.DOWN);
+        FakeProvider up = new FakeProvider("secondary");
+        RouteResolver resolver = resolver(props("primary", "secondary"), List.of(down, up));
+
+        ChatResponse r = resolver.route(request("auto"));
+
+        assertThat(r.provider()).isEqualTo("secondary");
+        assertThat(down.calls).isEqualTo(0);
+    }
+
+    @Test
+    void rejects_unknown_strategy() {
+        NautilusProperties p = props("primary");
+        p.getRouting().setStrategy("does-not-exist");
+        RouteResolver resolver = resolver(p, List.of(new FakeProvider("primary")));
+
+        assertThatThrownBy(() -> resolver.route(request("auto")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does-not-exist");
+    }
+
+    // ----- helpers -----
+
+    private static RouteResolver resolver(NautilusProperties props, List<LlmProvider> providers) {
+        ProviderRegistry registry = new ProviderRegistry(providers);
+        return new RouteResolver(props, registry, List.of(new PriorityRoutingStrategy()));
+    }
+
+    private static NautilusProperties props(String... providerNames) {
+        NautilusProperties p = new NautilusProperties();
+        p.getRouting().setStrategy("priority");
+        List<NautilusProperties.Provider> entries = new ArrayList<>();
+        for (int i = 0; i < providerNames.length; i++) {
+            NautilusProperties.Provider e = new NautilusProperties.Provider();
+            e.setName(providerNames[i]);
+            e.setPriority(i);
+            e.setEnabled(true);
+            entries.add(e);
+        }
+        p.getRouting().setProviders(entries);
+        return p;
+    }
+
+    private static ChatRequest request(String model) {
+        return new ChatRequest(model, List.of(ChatMessage.user("hi")), null, null, null, null, null);
+    }
+
+    /** Test double for LlmProvider with controllable health, support, and one-shot failure. */
+    static class FakeProvider implements LlmProvider {
+        final String name;
+        ProviderHealth health = ProviderHealth.UP;
+        String supportPattern = "*";
+        ProviderException nextThrow;
+        int calls;
+
+        FakeProvider(String name) { this.name = name; }
+
+        FakeProvider supportsPattern(String pattern) { this.supportPattern = pattern; return this; }
+        FakeProvider health(ProviderHealth h) { this.health = h; return this; }
+        FakeProvider throwOnce(ProviderException e) { this.nextThrow = e; return this; }
+
+        @Override public String name() { return name; }
+        @Override public ProviderHealth health() { return health; }
+
+        @Override
+        public boolean supports(String model) {
+            if ("*".equals(supportPattern)) return true;
+            String prefix = supportPattern.replace("*", "");
+            return model != null && model.startsWith(prefix);
+        }
+
+        @Override
+        public ChatResponse chat(ChatRequest request) {
+            calls++;
+            if (nextThrow != null) {
+                ProviderException e = nextThrow;
+                nextThrow = null;
+                throw e;
+            }
+            return ChatResponse.of(request.model(), name, ChatMessage.assistant("ok"), Usage.zero());
+        }
+    }
+}

--- a/src/test/java/com/kloudocean/nautilus/web/ChatControllerTest.java
+++ b/src/test/java/com/kloudocean/nautilus/web/ChatControllerTest.java
@@ -1,0 +1,87 @@
+package com.kloudocean.nautilus.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "nautilus.routing.strategy=priority",
+        "nautilus.routing.providers[0].name=mock",
+        "nautilus.routing.providers[0].priority=1",
+        "nautilus.routing.providers[0].enabled=true",
+        "nautilus.provider.mock.enabled=true"
+})
+class ChatControllerTest {
+
+    @Autowired private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        mvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Test
+    void mock_provider_echoes_user_message() throws Exception {
+        String body = """
+                {
+                  "model": "auto",
+                  "messages": [
+                    {"role": "user", "content": "ping"}
+                  ]
+                }
+                """;
+
+        mvc.perform(post("/v1/chat/completions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.provider").value("mock"))
+                .andExpect(jsonPath("$.model").value("auto"))
+                .andExpect(jsonPath("$.choices[0].message.role").value("assistant"))
+                .andExpect(jsonPath("$.choices[0].message.content").value("[mock] ping"))
+                .andExpect(jsonPath("$.choices[0].finish_reason").value("stop"))
+                .andExpect(jsonPath("$.usage.total_tokens").isNumber());
+    }
+
+    @Test
+    void rejects_request_with_empty_messages() throws Exception {
+        String body = """
+                {
+                  "model": "auto",
+                  "messages": []
+                }
+                """;
+
+        mvc.perform(post("/v1/chat/completions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.type").value("invalid_request_error"));
+    }
+
+    @Test
+    void rejects_request_with_missing_model() throws Exception {
+        String body = """
+                {
+                  "messages": [{"role": "user", "content": "hi"}]
+                }
+                """;
+
+        mvc.perform(post("/v1/chat/completions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Builds the **architectural foundation for v0.1** — a working vertical slice from HTTP to provider that everything else (real provider adapters, streaming, redaction, cost tracking, additional strategies, the starter module) plugs into without further refactoring.

```
HTTP (POST /v1/chat/completions, OpenAI-compatible)
  -> ChatController
    -> RouteResolver    (filter eligible providers, fallback on retryable errors)
      -> RoutingStrategy   (priority by default, SPI for round-robin / random / cost-aware / latency-aware)
        -> LlmProvider     (SPI; MockProvider ships, real ones plug in)
          -> ChatResponse  (OpenAI-compatible shape)
  <- ErrorAdvice (OpenAI-style {error:{type,message,provider?,status,timestamp}} envelope)
```

**Layers introduced:**

- **`domain/`** — OpenAI-compatible records: `ChatRequest`, `ChatMessage`, `ChatResponse`, `Choice`, `Usage`, `Role`. Wire format matches OpenAI's `/v1/chat/completions` so existing clients work without code changes.

- **`provider/`** — `LlmProvider` SPI (`name`, `supports`, `chat`, `health`), `ProviderHealth`, typed `ProviderException` with retryable-kind classification (`RATE_LIMIT` / `TIMEOUT` / `AUTH` / `UPSTREAM_ERROR` / `BAD_REQUEST` / `UNAVAILABLE`), and `MockProvider` that echoes the last user message so the gateway works before any real provider keys are configured.

- **`routing/`** — `RoutingStrategy` SPI, `PriorityRoutingStrategy` default impl, `ProviderRegistry` indexing beans by name, and `RouteResolver` which:
  - filters configured providers to `enabled && healthy && supports(model)` and sorts by configured priority,
  - delegates to the active strategy for the first pick,
  - **falls back to the next eligible** on retryable `ProviderException`,
  - surfaces `NoEligibleProviderException` (HTTP 503) when nothing matches or every attempted provider failed.

- **`web/`** — `ChatController` exposing `POST /v1/chat/completions` and `ErrorAdvice` mapping internal exceptions to a consistent `{error: {type, message, provider?, status, timestamp}}` envelope across 400 / 401 / 429 / 502 / 503 / 500.

- **`config/`** — `NautilusProperties` (`@ConfigurationProperties("nautilus")`) with `@Validated` bean-validation rules + a `NautilusPropertiesValidator` running at `ApplicationReadyEvent` that rejects:
  - provider names not registered as `LlmProvider` beans (with the registered list shown in the error),
  - duplicate provider names,
  - negative weights,
  - configurations with no enabled providers.

  This is the user-facing payoff for **#5**: clear, actionable startup errors when `application.yml` is misconfigured. Example error message:

  > `Provider 'claude' configured under nautilus.routing.providers but no LlmProvider bean is registered for it. Registered providers: [mock]. Either remove the entry, or enable/implement the matching provider.`

**Application config:**
- `application.yml` ships with a working default (priority strategy, mock provider enabled). The gateway boots and serves traffic on port 8080 with no extra setup — aligning the README quickstart claim with reality.
- Actuator exposes `/actuator/health` with liveness + readiness probes (Kubernetes-ready out of the box).

**Tests: 18, all green.**
- `ChatControllerTest` — end-to-end HTTP tests via `MockMvc`. Validates the OpenAI-compatible response shape and the error envelope on bad input (empty `messages`, missing `model`).
- `RouteResolverTest` — priority ordering, fallback on retryable error, no-fallback on non-retryable, `supports(model)` filtering, health filtering, unknown-strategy rejection.
- `PriorityRoutingStrategyTest` — first-eligible selection, empty list.
- `NautilusPropertiesValidationTest` — covers all four validator rules.
- `NautilusApplicationTests` — existing context-loads check still passes.

**Manual smoke (verified locally before push):**

```bash
$ curl localhost:8080/actuator/health
{"status":"UP","groups":["liveness","readiness"]}

$ curl -X POST localhost:8080/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"auto","messages":[{"role":"user","content":"hello nautilus"}]}'
{"id":"chatcmpl-...","object":"chat.completion","model":"auto","provider":"mock",
 "choices":[{"index":0,"message":{"role":"assistant","content":"[mock] hello nautilus"},"finish_reason":"stop"}],
 "usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}

$ curl -X POST localhost:8080/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"auto","messages":[]}'
{"error":{"type":"invalid_request_error","message":"messages: must not be empty","status":400,"timestamp":"..."}}
```

#### Which issue(s) this PR fixes:

Fixes #5

#### Special notes for reviewers:

This is intentionally a **single big PR** rather than 8 small ones because the layers are mutually-referential — splitting them produces churn and meaningless intermediate states. Once this lands, follow-up PRs are tightly scoped one-issue-at-a-time work:

- `feat: Anthropic Claude provider` — implements `LlmProvider` for Claude, plugs into the registry, no other layer changes
- `feat: OpenAI provider`
- `feat: Mistral provider` (closes #10)
- `feat: round-robin routing strategy` (closes #8)
- `feat: random routing strategy with weights` (closes #9)
- `feat: streaming (SSE) responses` — adds a streaming variant alongside `chat()`
- `feat: log redaction interceptor` — implements the spec from #15
- `feat: cost tracking persistence`

A few specific things to flag:

1. **Domain types double as wire types** — I deliberately did not split into a separate `web/dto/` layer. Since the domain shape is OpenAI's, wire == domain. If we ever need a different internal canonical model, we add a mapper at the controller boundary.

2. **`MockProvider` defaults to enabled** — `@ConditionalOnProperty(matchIfMissing = true)`. This means the README quickstart works out of the box, but production deployments should set `nautilus.provider.mock.enabled=false`. I'll add a docs note about this in a follow-up README polish PR.

3. **Fallback is in `RouteResolver`, not in the strategy** — strategies decide *first pick*; the resolver decides *what to do on failure*. This keeps `RoutingStrategy` implementations simple and lets us tune fallback policy globally (per-request `max-attempts`, backoff, streaming-fallback semantics) in one place. Matches the design described in `docs/guides/routing-strategies.md`.

4. **No streaming yet** — `request.stream=true` is parsed but the controller returns a non-streaming response. Streaming (SSE) is a separate PR; the request shape is forward-compatible.

5. **No JPA / database / Redis yet** — by design. v0.1 foundation is in-memory and stateless; persistence layers come with cost tracking + semantic cache PRs.

#### Changelog input

```
Added the architectural foundation for v0.1: provider SPI (`LlmProvider`), routing layer (`RoutingStrategy` SPI + `PriorityRoutingStrategy` + `RouteResolver` with retry/fallback on retryable provider errors), domain types matching OpenAI's chat-completions wire format, `POST /v1/chat/completions` controller, OpenAI-style error envelope, `MockProvider` for dev/test, `@Validated` `NautilusProperties` plus a startup validator that produces actionable error messages for misconfigured providers (#5), and Kubernetes-ready actuator probes.
```

#### Additional documentation

This section can be blank.

```
- docs/guides/routing-strategies.md  - aligns with the `RoutingStrategy` SPI
- docs/guides/log-redaction.md        - target spec for the upcoming redaction interceptor
- ROADMAP.md (Now / v0.1)             - this PR delivers the architectural prerequisites for the remaining v0.1 items
- Issue #5                            - configuration validation
```

#### Checklist

- [x] Code compiles (`./gradlew compileJava` — verified)
- [x] Tests pass (`./gradlew check` — 18/18 green, BUILD SUCCESSFUL)
- [x] Formatted (Java, no style violations)
- [x] New features have tests (4 new test classes, 17 new tests + 1 retained)
- [x] New user-facing features have docs updated (no doc-update needed yet — `application.yml` self-documents the v0.1 surface; CONTRIBUTING.md and README quickstart still match)
- [x] Commit messages follow conventional commits