### PR TITLE
docs: show Gradle snippet alongside Maven for nautilus-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ curl http://localhost:8080/v1/chat/completions \
 
 ### Add to a Spring Boot app
 
+**Gradle (Kotlin DSL — `build.gradle.kts`):**
+
+```kotlin
+implementation("com.kloudocean:nautilus-starter:0.1.0")
+```
+
+**Gradle (Groovy — `build.gradle`):**
+
+```groovy
+implementation 'com.kloudocean:nautilus-starter:0.1.0'
+```
+
+**Maven (`pom.xml`):**
+
 ```xml
 <dependency>
   <groupId>com.kloudocean</groupId>


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

The README's "Add to a Spring Boot app" section only showed a Maven `<dependency>` XML snippet. This is inconsistent with:

- The project's own build tool — Nautilus is built with **Gradle (Kotlin DSL)**, `build.gradle.kts`, `./gradlew`.
- `CONTRIBUTING.md` — every command in the contributor onboarding flow is `./gradlew ...`.
- Common Java OSS convention — Spring Projects, Micrometer, Resilience4j etc. lead with Gradle and offer Maven as a secondary form.

Adds **Gradle Kotlin DSL first** (matches the project's own build), **Gradle Groovy second** (still common in the JVM ecosystem), keeps the existing **Maven** snippet last for users who can't switch.

Diff is +14 lines in one section of the README. No code change.

#### Which issue(s) this PR fixes:

<!-- No tracking issue — caught during README review. -->

Fixes #

#### Special notes for reviewers:

If we'd rather show only one Gradle form (Kotlin DSL is the modern default), I can drop the Groovy block — just say the word. I included both because Spring Boot generators still default to Groovy in some flows and pasting the Kotlin form into a Groovy script silently fails.

#### Changelog input

```
README: added Gradle (Kotlin DSL and Groovy) dependency snippets alongside the existing Maven snippet for `nautilus-starter`.
```

#### Additional documentation

This section can be blank.

```
- build.gradle.kts (Kotlin DSL is the project's own build)
- CONTRIBUTING.md (uses ./gradlew throughout)
```

#### Checklist

- [x] Code compiles (no code change)
- [x] Tests pass (no code change)
- [x] Formatted (markdown only)
- [ ] New features have tests (n/a — docs)
- [x] New user-facing features have docs updated (this IS the doc)
- [x] Commit messages follow conventional commits