### PR TITLE
docs: fix Cross-cutting label overlapping Log Redaction pill in architecture SVG

### DIFF
--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -91,20 +91,20 @@
       <text x="572" y="328" text-anchor="middle" class="label-sub">OTel · slf4j</text>
     </g>
 
-    <!-- Row 3: redaction + auth + audit pill row -->
+    <!-- Row 3: cross-cutting concerns (label above, pills below — no overlap) -->
     <g>
-      <rect x="60" y="360" width="560" height="50" class="module"/>
-      <text x="80" y="384" class="label-strong">Cross-cutting</text>
-      <rect x="170" y="372" width="92" height="22" class="pill" rx="11" ry="11"/>
-      <text x="216" y="388" text-anchor="middle" class="pill-text">Log Redaction</text>
-      <rect x="270" y="372" width="78" height="22" class="pill" rx="11" ry="11"/>
-      <text x="309" y="388" text-anchor="middle" class="pill-text">API Keys</text>
-      <rect x="356" y="372" width="74" height="22" class="pill" rx="11" ry="11"/>
-      <text x="393" y="388" text-anchor="middle" class="pill-text">Audit Log</text>
-      <rect x="438" y="372" width="78" height="22" class="pill" rx="11" ry="11"/>
-      <text x="477" y="388" text-anchor="middle" class="pill-text">Health</text>
-      <rect x="524" y="372" width="86" height="22" class="pill" rx="11" ry="11"/>
-      <text x="567" y="388" text-anchor="middle" class="pill-text">Validation</text>
+      <rect x="60" y="350" width="560" height="62" class="module"/>
+      <text x="340" y="368" text-anchor="middle" class="label-sub" font-style="italic">cross-cutting concerns</text>
+      <rect x="78" y="378" width="100" height="24" class="pill" rx="12" ry="12"/>
+      <text x="128" y="395" text-anchor="middle" class="pill-text">Log Redaction</text>
+      <rect x="190" y="378" width="86" height="24" class="pill" rx="12" ry="12"/>
+      <text x="233" y="395" text-anchor="middle" class="pill-text">API Keys</text>
+      <rect x="288" y="378" width="84" height="24" class="pill" rx="12" ry="12"/>
+      <text x="330" y="395" text-anchor="middle" class="pill-text">Audit Log</text>
+      <rect x="384" y="378" width="78" height="24" class="pill" rx="12" ry="12"/>
+      <text x="423" y="395" text-anchor="middle" class="pill-text">Health</text>
+      <rect x="474" y="378" width="92" height="24" class="pill" rx="12" ry="12"/>
+      <text x="520" y="395" text-anchor="middle" class="pill-text">Validation</text>
     </g>
   </g>
 


### PR DESCRIPTION
#### What type of PR is this?

* fix
* documentation

#### What this PR does / why we need it:

Follow-up to #35. In the architecture SVG, the inline "Cross-cutting" left-side label and the first pill ("Log Redaction") both started near `x=170`, so the label text ran into the pill on render.

This PR restructures that single row in `docs/assets/architecture.svg`:

- Replaces the inline left label with an italicised centered sub-header *"cross-cutting concerns"* sitting **above** the pills.
- Lays out the five pills (Log Redaction, API Keys, Audit Log, Health, Validation) in a single row beneath, with even gaps and consistent widths.
- Container height grew from 50 → 62 to fit both lines comfortably.

No changes to any other diagram element. The Excalidraw source (`docs/assets/architecture.excalidraw`) is unchanged in this PR — the SVG is the canonical render that GitHub displays. Will sync the Excalidraw source in a follow-up after the next round of refinements there.

#### Which issue(s) this PR fixes:

<!-- No tracking issue — review feedback on #35. -->

Fixes #

#### Special notes for reviewers:

The overlap fix commit was pushed to the `docs/architecture-diagram` branch after #35 had already been merged, so the fix never landed on main. Cherry-picked here onto a fresh branch so it can ship cleanly.

#### Changelog input

```
Fixed a label/pill overlap in the architecture SVG (the "Cross-cutting" inline label was running into the "Log Redaction" pill).
```

#### Additional documentation

This section can be blank.

```
- docs/assets/architecture.svg — the diagram embedded in README
- Original PR: #35
```

#### Checklist

- [x] Code compiles (no code change)
- [x] Tests pass (no code change)
- [x] Formatted (SVG only)
- [ ] New features have tests (n/a — docs)
- [x] New user-facing features have docs updated (this IS the doc — README still embeds the same SVG path)
- [x] Commit messages follow conventional commits