### PR TITLE
docs: cache-bust architecture SVG in README (forces camo refresh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Full docs in [docs/](docs/). Start with the [routing strategies guide](docs/guid
 ## Architecture
 
 <p align="center">
-  <img src="docs/assets/architecture.svg" alt="Nautilus architecture: clients call the gateway, which routes across LLM providers (Claude, OpenAI, Llama, Mistral) with smart fallback, semantic caching (PostgreSQL + pgvector, Redis), rate limiting, cost tracking, and OpenTelemetry-based observability." width="100%" />
+  <img src="docs/assets/architecture.svg?v=2" alt="Nautilus architecture: clients call the gateway, which routes across LLM providers (Claude, OpenAI, Llama, Mistral) with smart fallback, semantic caching (PostgreSQL + pgvector, Redis), rate limiting, cost tracking, and OpenTelemetry-based observability." width="100%" />
 </p>
 
 Edit the diagram in [docs/assets/architecture.excalidraw](docs/assets/architecture.excalidraw) (open in [Excalidraw](https://excalidraw.com) or the VSCode extension) and re-export the SVG when you change it.


### PR DESCRIPTION
#### What type of PR is this?

* fix
* documentation

#### What this PR does / why we need it:

After #36 landed, `main`'s `docs/assets/architecture.svg` is correct (verified by hitting `raw.githubusercontent.com` directly), but README still renders the old version because GitHub's `camo.githubusercontent.com` image proxy cached the original. A new browser, a hard refresh, and incognito mode all show the cached copy.

Bumping the `<img src>` to `architecture.svg?v=2` changes the URL camo keys on, so it fetches a fresh copy. No file rename, no other change.

If we revise the SVG content again later and hit the same proxy-cache issue, bump to `?v=3`.

#### Which issue(s) this PR fixes:

<!-- No tracking issue — review feedback after #36 merge. -->

Fixes #

#### Special notes for reviewers:

After merging, hard-refresh the README page once. The diagram should immediately show the corrected version (italic *"cross-cutting concerns"* sub-header above the pills).

#### Changelog input

```
README: cache-busted the architecture SVG embed so the post-fix diagram renders correctly via GitHub's image proxy.
```

#### Additional documentation

This section can be blank.

```
- camo image proxy reference: https://github.blog/2014-01-28-proxying-user-images/
- Original fix PR: #36
```

#### Checklist

- [x] Code compiles (no code change)
- [x] Tests pass (no code change)
- [x] Formatted (markdown only — single-character change)
- [ ] New features have tests (n/a — docs)
- [x] New user-facing features have docs updated (this IS the doc)
- [x] Commit messages follow conventional commits